### PR TITLE
Update heading capitalisation

### DIFF
--- a/inst/supporting_files/css/06_html_report.css
+++ b/inst/supporting_files/css/06_html_report.css
@@ -8,13 +8,13 @@ h1 {
   margin-top: 1em;
   font-size: 2em;
   font-weight: bold;
-  text-transform: capitalize;
+  text-transform: none;
 }
 
 h2 {
   margin-top: 0.75em;
   font-size: 1.6em;
-  text-transform: capitalize;
+  text-transform: none;
 }
 
 h3 {


### PR DESCRIPTION
Update the capitalisation type so it preserves capitalisation typed in as is rather than capitalising every word in the sentence. Resolves issue #12